### PR TITLE
SYS-1481: Add Github Actions to test, build, and push to Docker Hub

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,46 @@
+name: Build and Test Link Shortener
+on: 
+  pull_request:
+  workflow_dispatch:
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+    env:
+      # Docker-compose file for testing via Github Actions
+      COMPOSE_FILE: docker-compose.ga.yml
+    steps:
+      - uses: actions/checkout@v2
+      
+      - name: Build the stack
+        run: docker-compose -f $COMPOSE_FILE up --build -d
+      
+      - name: Wait for database
+        run: sleep 15s
+        shell: bash
+
+        # Check logs separately, GA not showing all of both together
+      - name: Logs (db)
+        run: docker-compose -f $COMPOSE_FILE logs --tail="all" db
+
+      - name: Logs (django)
+        run: docker-compose -f $COMPOSE_FILE logs --tail="all" django
+
+      - name: Containers
+        run: docker-compose -f $COMPOSE_FILE ps
+
+      - name: Top processes
+        run: docker-compose -f $COMPOSE_FILE top
+
+      - name: Create models
+        run: docker-compose -f $COMPOSE_FILE exec -T django python manage.py migrate
+      
+      - name: Load data
+        run: docker-compose -f $COMPOSE_FILE exec -T django python manage.py loaddata sample_data.json
+      
+      - name: Check connectivity
+        #run: docker run --network container:django-frontend appropriate/curl -s -I http://localhost:8000/admin/
+        run: curl -s -I http://localhost:8000/admin/
+      
+      - name: Run tests
+        # -T to disable TTY allocation
+        run: docker-compose -f $COMPOSE_FILE exec -T django python manage.py test

--- a/.github/workflows/build_docker_hub.yml
+++ b/.github/workflows/build_docker_hub.yml
@@ -1,0 +1,38 @@
+name: Build for Docker Hub Link Shortener
+on: 
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+jobs:
+  build_for_docker_hub:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Read chart yaml to get version for docker tag
+        id: yaml-data
+        uses: KJ002/read-yaml@1.6
+        with:
+          file: 'charts/prod-linkshortener-values.yaml'
+          key-path: '["image", "tag"]'
+
+      - name: Display yaml info
+        run: echo "${{ steps.yaml-data.outputs.data }}"
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: uclalibrary/link-shortener:${{ steps.yaml-data.outputs.data }}

--- a/charts/prod-linkshortener-values.yaml
+++ b/charts/prod-linkshortener-values.yaml
@@ -1,0 +1,75 @@
+# Values for link-shortener prod.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: uclalibrary/link-shortener
+  tag: v1.0.0
+  pullPolicy: Always
+
+nameOverride: ""
+
+fullnameOverride: ""
+
+service:
+  type: ClusterIP
+  port: 80
+  
+ingress:
+  enabled: "true"
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+    cert-manager.io/cluster-issuer: sectigo-acme-clusterissuer
+    kubernetes.io/tls-acme: "true"
+
+  hosts:
+    - host: 'go.library.ucla.edu'
+      paths:
+        - "/"
+  tls:
+  - secretName: link-shortener-tls
+    hosts:
+      - go.library.ucla.edu
+
+django:
+  env:
+    run_env: "prod"
+    debug: "false"
+    allowed_hosts:
+      - go.library.ucla.edu
+    csrf_trusted_origins:
+      - https://go.library.ucla.edu
+    link_prefix: "https://go.library.ucla.edu"
+    log_level: "INFO"
+    db_backend: "django.db.backends.postgresql_psycopg2"
+    db_name: "link_shortener"
+    db_user: "link_shortener"
+    db_host: "p-d-postgres.library.ucla.edu"
+    db_port: 5432
+
+  externalSecrets:
+    enabled: "true"
+    annotations: 
+      argocd.argoproj.io/sync-wave: "-1"
+    env:
+      # Application database used by django
+      db_password: "/systems/prodrke01/link-shortener/db_password"
+      django_secret_key: "/systems/prodrke01/link-shortener/django_secret_key"
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 500Mi
+  requests:
+    cpu: 250m
+    memory: 100Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/docker-compose.ga.yml
+++ b/docker-compose.ga.yml
@@ -1,0 +1,24 @@
+# Docker-compose file for testing via Github Actions
+version: "3.1"
+services:
+  django:
+    container_name: django-frontend
+    build: .
+    # Don't mount code for editing, in CI context
+    # volumes: 
+    # - .:/home/django/link-shortener
+    ports: 
+      - "8000:8000"
+    env_file:
+      - .docker-compose_django.env
+      - .docker-compose_db.env
+    depends_on:
+      - db
+  db:
+    image: postgres:12
+    env_file:
+      - .docker-compose_db.env
+    volumes:
+      - pg_data:/var/lib/postgresql/data/
+volumes:
+  pg_data:


### PR DESCRIPTION
Implements [SYS-1481](https://uclalibrary.atlassian.net/browse/SYS-1481).

This PR adds scripts and supporting files for two Github Actions:
* `build_and_test.yml`: Builds the application for testing, which must pass before a PR can be merged
  * `docker-compose.ga.yml`: A docker-compose file specifically for building the test application
* `build_docker_hub.yml`: Builds a docker image and pushes it to Docker Hub.  This is done when PRs are merged.
  * `charts/prod-linkshortener-values.yaml`: Provides version tag information for the Docker Hub build.


[SYS-1481]: https://uclalibrary.atlassian.net/browse/SYS-1481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ