### PR TITLE
Remove unused ALMA_API_KEY from chart secrets

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "0.1"
 description: Chart for Link Shortener application
 name: link-shortener
-version: 1.0.0
+version: 1.0.1

--- a/charts/templates/externalsecret.yaml
+++ b/charts/templates/externalsecret.yaml
@@ -21,6 +21,3 @@ spec:
     - secretKey: "DJANGO_DB_PASSWORD"
       remoteRef:
         key: {{ .Values.django.externalSecrets.env.db_password }}
-    - secretKey: "ALMA_API_KEY"
-      remoteRef:
-        key: {{ .Values.django.externalSecrets.env.alma_api_key }}

--- a/charts/templates/secrets.yaml
+++ b/charts/templates/secrets.yaml
@@ -10,5 +10,4 @@ type: Opaque
 data:
   DJANGO_SECRET_KEY: {{ randAlphaNum 20 | b64enc | quote }}
   DJANGO_DB_PASSWORD: {{ .Values.django.env.db_password | b64enc | quote }}
-  ALMA_API_KEY: {{ .Values.django.env.alma_api_key | b64enc | quote }}
 {{ end }}


### PR DESCRIPTION
Removes the overlooked and unused `ALMA_API_KEY` secret reference from this chart.  Bumps main chart version to `1.0.1`.