### PR TITLE
SYS-1486: Add HTTP referer header to redirects

### DIFF
--- a/charts/prod-linkshortener-values.yaml
+++ b/charts/prod-linkshortener-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/link-shortener
-  tag: v1.0.3
+  tag: v1.0.4
   pullPolicy: Always
 
 nameOverride: ""

--- a/shortlinks/templates/shortlinks/release_notes.html
+++ b/shortlinks/templates/shortlinks/release_notes.html
@@ -4,6 +4,14 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.0.4</h4>
+<p><i>December 21, 2023</i></p>
+<ul>
+    <li>
+        Add HTTP <em>Referer</em> header to redirects.
+    </li>
+</ul>
+
 <h4>1.0.3</h4>
 <p><i>December 19, 2023</i></p>
 <ul>

--- a/shortlinks/views_utils.py
+++ b/shortlinks/views_utils.py
@@ -31,3 +31,11 @@ def get_links(owner: AbstractBaseUser = None) -> QuerySet:
         short_link=Concat(Value(link_prefix), "short_path", output_field=CharField())
     ).order_by("-create_date")
     return links
+
+
+def get_short_link(short_path: str) -> str:
+    """Return a short_link: an absolute URL using the short_path.
+    This duplicates the simple concatenation logic in get_links(),
+    but uses different access logic and does not hit the database.
+    """
+    return settings.LINK_PREFIX + short_path


### PR DESCRIPTION
Implements [SYS-1486](https://uclalibrary.atlassian.net/browse/SYS-1486).  Tagged as `v1.0.4` for deployment.

This PR modifies the `redirect_link()` view to add a `Referer` (sic) header to the HTTP response.  It adds a utility function `get_short_link()` which returns an absolute URL from the requested path (e.g., `http://127.0.0.1:8000/use` from `/use`), and sets `Referer` to that URL.

It also adds 2 tests in a new `TestCase`, showing the use of the built-in Django client for testing HTTP requests/responses.

### Testing
1. Confirm all 6 tests pass.
2. (Optional) Use `curl` to confirm the `Referer` header is really there and set to the same value as the requested URL:
```
$ curl -I http://127.0.0.1:8000/public

HTTP/1.1 302 Found
Date: Thu, 21 Dec 2023 23:52:13 GMT
Server: WSGIServer/0.2 CPython/3.11.5
Content-Type: text/html; charset=utf-8
Location: https://www.library.ucla.edu/help/services-for-the-general-public
Referer: http://127.0.0.1:8000/public
X-Frame-Options: DENY
X-Content-Type-Options: nosniff
Referrer-Policy: same-origin
Cross-Origin-Opener-Policy: same-origin
```


[SYS-1486]: https://uclalibrary.atlassian.net/browse/SYS-1486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ