### PR TITLE
SYS-1494: Update django from 4.2.7 to 4.2.11

### DIFF
--- a/charts/prod-linkshortener-values.yaml
+++ b/charts/prod-linkshortener-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/link-shortener
-  tag: v1.0.5
+  tag: v1.0.6
   pullPolicy: Always
 
 nameOverride: ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==4.2.7
+Django==4.2.11
 gunicorn==21.2.0
 psycopg2==2.9.7
 whitenoise==6.5.0

--- a/shortlinks/templates/shortlinks/release_notes.html
+++ b/shortlinks/templates/shortlinks/release_notes.html
@@ -4,6 +4,14 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.0.6</h4>
+<p><i>March 19, 2024</i></p>
+<ul>
+    <li>
+        Upgrade Update from 4.2.7 to 4.2.11.
+    </li>
+</ul>
+
 <h4>1.0.5</h4>
 <p><i>January 5, 2024</i></p>
 <ul>

--- a/shortlinks/templates/shortlinks/release_notes.html
+++ b/shortlinks/templates/shortlinks/release_notes.html
@@ -8,7 +8,7 @@
 <p><i>March 19, 2024</i></p>
 <ul>
     <li>
-        Upgrade Update from 4.2.7 to 4.2.11.
+        Upgrade Django from 4.2.7 to 4.2.11.
     </li>
 </ul>
 

--- a/shortlinks/views.py
+++ b/shortlinks/views.py
@@ -72,7 +72,7 @@ def delete_link(request: HttpRequest, link_id: int) -> HttpResponse:
     link = get_object_or_404(Link, pk=link_id)
     link.delete()
     # Go back to the calling page
-    return HttpResponseRedirect(request.META.get("HTTP_REFERER"))
+    return HttpResponseRedirect(request.headers.get("referer"))
 
 
 @login_required

--- a/shortlinks/views_utils.py
+++ b/shortlinks/views_utils.py
@@ -51,6 +51,6 @@ def capture_usage_stats(link: Link, request: HttpRequest) -> None:
         link=link,
         client_ip=request.META.get("REMOTE_ADDR", ""),
         query_string=request.META.get("QUERY_STRING", ""),
-        referrer=request.META.get("HTTP_REFERER", ""),
-        user_agent=request.META.get("HTTP_USER_AGENT", ""),
+        referrer=request.headers.get("referer", ""),
+        user_agent=request.headers.get("user-agent", ""),
     )


### PR DESCRIPTION
Changes from request.META to request.headers were done automatically by django-updater. Probably not necessary, but 🤷