### PR TITLE
Update Django, PostgreSQL, and Python

### DIFF
--- a/.docker-compose_db.env
+++ b/.docker-compose_db.env
@@ -9,7 +9,7 @@
 ###
 
 # Used in project/settings.py
-DJANGO_DB_BACKEND=django.db.backends.postgresql_psycopg2
+DJANGO_DB_BACKEND=django.db.backends.postgresql
 DJANGO_DB_HOST=db
 DJANGO_DB_PORT=5432
 DJANGO_DB_NAME=link_shortener

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM python:3.12-slim-bookworm
+FROM python:3.13-slim-bookworm
 
 RUN apt-get update
 
 # Set correct timezone
 RUN ln -sf /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
 
-# Install dependencies needed to build psycopg2 python module
+# Install dependencies needed to build psycopg python module
 RUN apt-get install -y gcc python3-dev libpq-dev
 
 # Create django user

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ The development environment requires:
 
 #### PostgreSQL container
 
-The development database is a Docker container running PostgreSQL 12, which matches our deployment environment.
+The development database is a Docker container running PostgreSQL 16, which matches our deployment environment.
 
 #### Django container
 
-This uses Django 4.2, in a Debian 11 (Bullseye) container running Python 3.11.  All code 
+This uses Django 5.2, in a Debian 11 (Bullseye) container running Python 3.13.  All code 
 runs in the container, so local version of Python does not matter.
 
 The container runs via `docker_scripts/entrypoint.sh`, which

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The development database is a Docker container running PostgreSQL 16, which matc
 
 #### Django container
 
-This uses Django 5.2, in a Debian 11 (Bullseye) container running Python 3.13.  All code 
+This uses Django 5.2, in a Debian 12 (Bookworm) container running Python 3.13.  All code 
 runs in the container, so local version of Python does not matter.
 
 The container runs via `docker_scripts/entrypoint.sh`, which

--- a/charts/prod-linkshortener-values.yaml
+++ b/charts/prod-linkshortener-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/link-shortener
-  tag: v1.0.8
+  tag: v1.0.9
   pullPolicy: Always
 
 nameOverride: ""
@@ -45,7 +45,7 @@ django:
       - https://go.library.ucla.edu
     link_prefix: "https://go.library.ucla.edu"
     log_level: "INFO"
-    db_backend: "django.db.backends.postgresql_psycopg2"
+    db_backend: "django.db.backends.postgresql"
     db_name: "link_shortener"
     db_user: "link_shortener"
     db_host: "p-d-postgres.library.ucla.edu"

--- a/docker-compose.ga.yml
+++ b/docker-compose.ga.yml
@@ -6,7 +6,7 @@ services:
     # Don't mount code for editing, in CI context
     # volumes: 
     # - .:/home/django/link-shortener
-    ports: 
+    ports:
       - "8000:8000"
     env_file:
       - .docker-compose_django.env
@@ -14,7 +14,7 @@ services:
     depends_on:
       - db
   db:
-    image: postgres:12
+    image: postgres:16
     env_file:
       - .docker-compose_db.env
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,20 +2,20 @@ services:
   django:
     build: .
     # tty: true
-    volumes: 
+    volumes:
       - .:/home/django/link-shortener
     env_file:
       - .docker-compose_django.env
       - .docker-compose_db.env
       # Local development only
       # - .docker-compose_secrets.env
-    ports: 
+    ports:
       # Variables here must be set in environment, or in .env - not in any env_file
       - "8000:8000"
     depends_on:
       - db
   db:
-    image: postgres:12
+    image: postgres:16
     env_file:
       - .docker-compose_db.env
     volumes:

--- a/docker_scripts/entrypoint.sh
+++ b/docker_scripts/entrypoint.sh
@@ -11,7 +11,7 @@ fi
 
 # Check when database is ready for connections
 echo "Checking database connectivity..."
-until python -c 'import os, psycopg2 ; conn = psycopg2.connect(host=os.environ.get("DJANGO_DB_HOST"),port=os.environ.get("DJANGO_DB_PORT"),user=os.environ.get("DJANGO_DB_USER"),password=os.environ.get("DJANGO_DB_PASSWORD"),dbname=os.environ.get("DJANGO_DB_NAME"))' ; do
+until python -c 'import os, psycopg ; conn = psycopg.connect(host=os.environ.get("DJANGO_DB_HOST"),port=os.environ.get("DJANGO_DB_PORT"),user=os.environ.get("DJANGO_DB_USER"),password=os.environ.get("DJANGO_DB_PASSWORD"),dbname=os.environ.get("DJANGO_DB_NAME"))' ; do
   echo "Database connection not ready - waiting"
   sleep 5
 done

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Django==4.2.19
+Django==5.2.1
 gunicorn==23.0.0
-psycopg2==2.9.7
+psycopg==3.2.9
 whitenoise==6.5.0
 django-bootstrap5 == 23.3

--- a/shortlinks/templates/shortlinks/base.html
+++ b/shortlinks/templates/shortlinks/base.html
@@ -8,11 +8,11 @@
 <head>
     <title>UCLA Library Link Shortener</title>
     <!-- Custom CSS -->
-    <link rel="stylesheet" type="text/css" href="{% static 'css/style.css' %}"/>
+    <link rel="stylesheet" type="text/css" href="{% static 'css/style.css' %}" />
     <!-- Custom JS -->
     <script src="{% static 'js/main.js' %}" defer></script>
     <!-- Favicon -->
-    <link rel="icon" type="image/x-icon" href="{% static 'favicon.ico' %}"/>
+    <link rel="icon" type="image/x-icon" href="{% static 'favicon.ico' %}" />
 </head>
 
 <body>
@@ -22,7 +22,12 @@
         <li><a href="/all_links/">All Links</a></li>
         <li><a href="/logs/">Logs</a></li>
         <li><a href="/release_notes/">Release Notes</a></li>
-        <li><a href="/accounts/logout/">Logout</a></li>
+        <li>
+            <form method="post" action="{% url 'logout' %}">
+                {% csrf_token %}
+                {% bootstrap_button "Logout" button_type="submit" button_class="link-primary" %}
+            </form>
+        </li>
     </ul>
     <br>
     <div class="container">

--- a/shortlinks/templates/shortlinks/release_notes.html
+++ b/shortlinks/templates/shortlinks/release_notes.html
@@ -2,7 +2,21 @@
 
 {% block content %}
 <h3>Release Notes</h3>
-<hr/>
+<hr />
+
+<h4>1.0.9</h4>
+<p><i>May 16, 2025</i></p>
+<ul>
+    <li>
+        Update Django to version 5.2.1.
+    </li>
+    <li>
+        Update Python to version 3.13.
+    </li>
+    <li>
+        Update psycopg to version 3.2.9 to go with PostgreSQL 16.
+    </li>
+</ul>
 
 <h4>1.0.8</h4>
 <p><i>February 25, 2025</i></p>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -20,13 +20,18 @@ ul.navbar {
     text-decoration: none;
 }
 
+.navbar li form {
+    display: inline;
+}
+
 .box {
     margin: 10px;
     padding: 10px;
     border: 1px solid black;
 }
 
-.search-results th, .search-results td {
+.search-results th,
+.search-results td {
     padding: 4px;
     border: 1px solid;
     vertical-align: top;


### PR DESCRIPTION
Implements [SYS-1828](https://uclalibrary.atlassian.net/browse/SYS-1828)

#### Summary

* upgrade Django 4.2.19 -> 5.2.1
* upgrade PostgreSQL 14 -> 16
  * psycopg 2.9.7 -> 3.2.9, to go with Postgres upgrade
* upgrade Python 3.12 -> 3.13
* bump version to 1.0.9 for deployment
* update release notes
* update README

#### Compatibility checks and tests
Installing and running `upgrade-django` yielded no flags or changes prior to upgrades.

All unit tests passed after upgrades. Application is available on `localhost` and appears to be working fine.

[SYS-1828]: https://uclalibrary.atlassian.net/browse/SYS-1828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ